### PR TITLE
Add possibility to set attribute name the same as label

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -24,13 +24,14 @@ class Form
     protected $action;
     protected $theme;
     protected $class;
-    protected $elements  = [];
-    protected $errors    = [];
-    protected $validated = false;
-    protected $name      = false;
-    protected $isAjax    = false;
+    protected $elements                = [];
+    protected $errors                  = [];
+    protected $validated               = false;
+    protected $name                    = false;
+    protected $isAjax                  = false;
     protected $enctype;
-    protected $disabled  = false;
+    protected $disabled                = false;
+    protected $useLabelAsAttributeName = false;
 
     public function __construct()
     {
@@ -162,6 +163,18 @@ class Form
         $this->class .= ' ' . $class;
 
         return $this;
+    }
+
+    public function useLabelAsAttributeName($useLabelAsAttributeName = true)
+    {
+        $this->useLabelAsAttributeName = $useLabelAsAttributeName;
+
+        return $this;
+    }
+
+    public function isUseLabelAsAttributeName()
+    {
+        return $this->useLabelAsAttributeName;
     }
 
     /**

--- a/src/Form/Element.php
+++ b/src/Form/Element.php
@@ -212,6 +212,12 @@ abstract class Element
         $values    = request($keys);
 
         $validator = $validator->setData($values);
+        
+        if ($this->form && $this->form->isUseLabelAsAttributeName() && $this->label)
+        {
+            $validator->setAttributeNames([$this->name => $this->label]);
+        }
+
         $validator = $validator->setRules([
             $this->name => $this->validators
         ]);


### PR DESCRIPTION
It is used for returning form errors 
Errors for example:
Was: The details.length_day_minutes field is required.
Became: The Length of day in minutes field is required.
